### PR TITLE
Update MarkovModel & BayesianModel to MarkovNetwork & BayesianNetwork

### DIFF
--- a/bnsobol/indices.py
+++ b/bnsobol/indices.py
@@ -1,6 +1,6 @@
 import numpy as np
 import copy
-from pgmpy.models import BayesianModel, MarkovModel
+from pgmpy.models import MarkovNetwork, BayesianNetwork
 from pgmpy.inference import VariableElimination
 from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.factors import factor_product
@@ -12,15 +12,15 @@ def variance(m, b, inputs, heuristic='MinWeight'):
     Compute the variance of an MRF `m` with respect to probability
     `b` and variables in `inputs`
 
-    :param m: a `MarkovModel` encoding the function of interest
-    :param b: a `BayesianModel` encoding the distribution of its inputs
+    :param m: a `MarkovNetwork` encoding the function of interest
+    :param b: a `BayesianNetwork` encoding the distribution of its inputs
     :param inputs: a list of variables
 :param heuristic: one of the elimination order heuristics supported by pgmpy. Default is 'MinWeight'
     :return: a scalar, Var[f]
     """
 
-    assert isinstance(m, MarkovModel)
-    assert isinstance(b, BayesianModel)
+    assert isinstance(m, MarkovNetwork)
+    assert isinstance(b, BayesianNetwork)
 
     e2x = bn.util.eliminate(m, to_keep=[], heuristic=heuristic, output='factor').values**2
 
@@ -37,16 +37,16 @@ def variance_component(m, b, inputs, i, heuristic='MinWeight'):
     """
     Compute the variance component of one of the input nodes on the expected value of an output node
 
-    :param m: a `MarkovModel` encoding the function of interest
-    :param b: a `BayesianModel` encoding the distribution of its inputs
+    :param m: a `MarkovNetwork` encoding the function of interest
+    :param b: a `BayesianNetwork` encoding the distribution of its inputs
     :param inputs: a list of strings (input variables)
     :param i: name of the node of interest
     :param heuristic: one of the elimination order heuristics supported by pgmpy. Default is 'MinWeight'
     :return: a scalar, S_i
     """
 
-    assert isinstance(m, MarkovModel)
-    assert isinstance(b, BayesianModel)
+    assert isinstance(m, MarkovNetwork)
+    assert isinstance(b, BayesianNetwork)
     assert all([j in m.nodes for j in inputs])
     assert all([j in b.nodes for j in inputs])
     if not isinstance(i, (list, tuple)):
@@ -78,16 +78,16 @@ def total_index(m, b, inputs, i, heuristic='MinWeight'):
 
     Saltelli, A. et al.: "Global Sensitivity Analysis: The Primer" (2008)
 
-    :param m: a `MarkovModel` encoding the function of interest
-    :param b: a `BayesianModel` encoding the distribution of its inputs
+    :param m: a `MarkovNetwork` encoding the function of interest
+    :param b: a `BayesianNetwork` encoding the distribution of its inputs
     :param inputs: a list of strings (input variables)
     :param i: name of the node of interest
     :param heuristic: one of the elimination order heuristics supported by pgmpy. Default is 'MinWeight'
     :return: a scalar, S^T_i
     """
 
-    assert isinstance(m, MarkovModel)
-    assert isinstance(b, BayesianModel)
+    assert isinstance(m, MarkovNetwork)
+    assert isinstance(b, BayesianNetwork)
     assert all([j in m.nodes for j in inputs])
     assert all([j in b.nodes for j in inputs])
     assert i in inputs

--- a/bnsobol/viz.py
+++ b/bnsobol/viz.py
@@ -10,7 +10,7 @@ def plot_graph(b, inputs, indices=None, output=None, filename=None):
     """
     Show a network and the sensitivity of an output with respect to a list of indices.
 
-    :param b: a Bayesian network (`pgmpy.models.BayesianModel`)
+    :param b: a Bayesian network (`pgmpy.models.BayesianNetwork`)
     :param inputs: a list of nodes
     :param indices: a list of numbers (like sensitivity indices) to be shown under each input. If None (default), no numbers will be shown
     :param output: a node. If None (default), no output will be shown

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -6,7 +6,7 @@ import bnsobol as bn
 import numpy as np
 import torch
 import tntorch as tn
-from pgmpy.models import BayesianModel
+from pgmpy.models import BayesianNetwork
 from pgmpy.factors.discrete import TabularCPD
 
 
@@ -14,10 +14,10 @@ def five_nodes():
     """
     Toy BN with two correlated inputs.
 
-    :return: a `BayesianModel`
+    :return: a `BayesianNetwork`
     """
 
-    g = BayesianModel([
+    g = BayesianNetwork([
         ('A', 'B'),
         ('A', 'C'),
         ('C', 'B'),
@@ -54,10 +54,10 @@ def five_nodes_uncorrelated():
     """
     Toy BN with two uncorrelated inputs.
 
-    :return: a `BayesianModel`
+    :return: a `BayesianNetwork`
     """
 
-    g = BayesianModel([
+    g = BayesianNetwork([
         # ('A', 'B'),
         ('A', 'C'),
         ('B', 'D'),
@@ -93,10 +93,10 @@ def five_nodes_uniform():
     """
     Toy BN with two correlated inputs.
 
-    :return: a `BayesianModel`
+    :return: a `BayesianNetwork`
     """
 
-    g = BayesianModel([
+    g = BayesianNetwork([
         ('A', 'C'),
         ('B', 'D'),
         ('B', 'E'),


### PR DESCRIPTION
`MarkovModel` and `BayesianModel` are deprecated by `pgmpy`.